### PR TITLE
fix: adjust centre of mass when vehicle isn't grounded

### DIFF
--- a/game/src/engine/physics/PhysicsService.cpp
+++ b/game/src/engine/physics/PhysicsService.cpp
@@ -429,9 +429,9 @@ std::optional<RaycastData> PhysicsService::RaycastStatic(
 
     if (debug_draw_raycast_)
     {
-        LineVertex start(PxToGlm(px_origin), Color4u(255, 0, 0, 255));
+        LineVertex start(PxToGlm(px_origin), Color4u(0, 0, 255, 255));
         LineVertex end(PxToGlm(px_origin + px_unit_dir * max_distance),
-                       Color4u(0, 255, 0, 255));
+                       Color4u(0, 0, 255, 255));
         render_service_->GetDebugDrawList().AddLine(start, end);
     }
 

--- a/game/src/engine/physics/PhysicsService.cpp
+++ b/game/src/engine/physics/PhysicsService.cpp
@@ -367,7 +367,7 @@ void PhysicsService::DrawDebugParamWidget(
 }
 
 /* ---------- raycasting ---------- */
-std::optional<RaycastData> PhysicsService::Raycast(
+std::optional<RaycastData> PhysicsService::RaycastDynamic(
     const glm::vec3& origin, const glm::vec3& unit_dir,
     float max_distance /* default = 100000 */)
 {
@@ -424,14 +424,6 @@ std::optional<RaycastData> PhysicsService::Raycast(
 
     return result;
 }
-
-// TODO !!!!
-/* std::optional<RaycastData> PhysicsService::Sweep() */
-/* { */
-/*     PxSweepCallback sweep_result; */
-/*     PxGeometryType shape = PxGeometryType::eCONVEXMESH; */
-/*     kScene_->sweep(shape,); */
-/* } */
 
 /* ---------- PhysX ----------*/
 void PhysicsService::InitPhysX()

--- a/game/src/engine/physics/PhysicsService.h
+++ b/game/src/engine/physics/PhysicsService.h
@@ -89,7 +89,7 @@ class PhysicsService final : public Service,
                    const physx::PxU32 count) override;
 
     /*
-     * Casts a ray until the nearest object or no object is hit.
+     * Casts a ray until the nearest DYNAMIC object or no object is hit.
      *
      * @param origin location from which we cast ray : glm::vec3
      * @param unit_dir direction of the ray casted : glm::vec3
@@ -99,9 +99,17 @@ class PhysicsService final : public Service,
      *      is successful (i.e something was hit)
      *      or nothing when a cast is unsuccessful
      */
-    std::optional<RaycastData> Raycast(const glm::vec3& origin,
-                                       const glm::vec3& unit_dir,
-                                       float max_distance = 100000);
+    std::optional<RaycastData> RaycastDynamic(const glm::vec3& origin,
+                                              const glm::vec3& unit_dir,
+                                              float max_distance = 100000);
+    /*
+     * Casts a ray until the nearest STATIC object or no object is hit.
+     *
+     * @see RaycastDynamic
+     */
+    std::optional<RaycastData> RaycastStatic(const glm::vec3& origin,
+                                             const glm::vec3& unit_dir,
+                                             float max_distance = 100000);
 
     std::optional<RaycastData> Sweep();
 

--- a/game/src/game/components/Controllers/AIController.cpp
+++ b/game/src/game/components/Controllers/AIController.cpp
@@ -121,7 +121,7 @@ void AIController::OnUpdate(const Timestep& delta_time)
 
     // if an entity is within view
     bool saw_something =
-        physics_service_->Raycast(origin, forward, kViewDistance).has_value();
+        physics_service_->RaycastDynamic(origin, forward, kViewDistance).has_value();
     if (saw_something && WillShoot(0.75f))
     {
         CheckShoot(delta_time);

--- a/game/src/game/components/VehicleComponent.cpp
+++ b/game/src/game/components/VehicleComponent.cpp
@@ -210,8 +210,12 @@ void VehicleComponent::AdjustCentreOfMass()
     glm::vec3 down = glm::vec3{0.0f, -1.0f, 0.0f};
     // check if vehicle is grounded
 
-    auto raycast_data = physics_service_->RaycastStatic(position, down, 10.0f);
+    auto raycast_data = physics_service_->RaycastStatic(position, down, 2.0f);
 
+    if (!raycast_data.has_value())
+        debug::LogDebug("Entity {} adjusting cMass...", GetEntity().GetId());
+    else 
+        debug::LogDebug("Entity {} grounded", GetEntity().GetId());
     PxTransform cmass = (raycast_data.has_value())        //
                             ? PxTransform{0.f, 0.f, 0.f}  //
                             : PxTransform{0.f, 0.f, 2.f};

--- a/game/src/game/components/VehicleComponent.cpp
+++ b/game/src/game/components/VehicleComponent.cpp
@@ -74,7 +74,6 @@ void VehicleComponent::InitVehicle()
 
     rigidbody->userData = &GetEntity();
     rigidbody->setActorFlag(physx::PxActorFlag::eVISUALIZATION, true);
-    // rigidbody->setCMassLocalPose();
     const uint32_t num_shapes = rigidbody->getNbShapes();
     PxShape* shape = nullptr;
 
@@ -199,6 +198,26 @@ void VehicleComponent::OnUpdate(const Timestep& delta_time)
     }
 
     HandleVehicleTransform();
+    AdjustCentreOfMass();
+}
+
+void VehicleComponent::AdjustCentreOfMass()
+{
+    PxRigidBody* rigidbody = vehicle_.mPhysXState.physxActor.rigidBody;
+
+    glm::vec3 position = transform_->GetPosition();
+    glm::vec3 down = -transform_->GetUpDirection();
+    // check if vehicle is grounded
+
+    auto raycast_data = physics_service_->RaycastStatic(position, down, 50.0f);
+    if (!raycast_data.has_value())
+        debug::LogDebug("{} not grounded.", GetEntity().GetId());
+
+    /* PxTransform cmass = (raycast_data.has_value())        // */
+    /*                         ? PxTransform{0.f, 0.f, 0.f}  // */
+    /*                         : PxTransform{0.f, 2.f, 5.f}; */
+
+    /* rigidbody->setCMassLocalPose(cmass); */
 }
 
 void VehicleComponent::OnPhysicsUpdate(const Timestep& step)

--- a/game/src/game/components/VehicleComponent.cpp
+++ b/game/src/game/components/VehicleComponent.cpp
@@ -206,18 +206,17 @@ void VehicleComponent::AdjustCentreOfMass()
     PxRigidBody* rigidbody = vehicle_.mPhysXState.physxActor.rigidBody;
 
     glm::vec3 position = transform_->GetPosition();
-    glm::vec3 down = -transform_->GetUpDirection();
+    /* glm::vec3 down = -transform_->GetUpDirection(); */
+    glm::vec3 down = glm::vec3{0.0f, -1.0f, 0.0f};
     // check if vehicle is grounded
 
-    auto raycast_data = physics_service_->RaycastStatic(position, down, 50.0f);
-    if (!raycast_data.has_value())
-        debug::LogDebug("{} not grounded.", GetEntity().GetId());
+    auto raycast_data = physics_service_->RaycastStatic(position, down, 10.0f);
 
-    /* PxTransform cmass = (raycast_data.has_value())        // */
-    /*                         ? PxTransform{0.f, 0.f, 0.f}  // */
-    /*                         : PxTransform{0.f, 2.f, 5.f}; */
+    PxTransform cmass = (raycast_data.has_value())        //
+                            ? PxTransform{0.f, 0.f, 0.f}  //
+                            : PxTransform{0.f, 0.f, 2.f};
 
-    /* rigidbody->setCMassLocalPose(cmass); */
+    rigidbody->setCMassLocalPose(cmass);
 }
 
 void VehicleComponent::OnPhysicsUpdate(const Timestep& step)

--- a/game/src/game/components/VehicleComponent.h
+++ b/game/src/game/components/VehicleComponent.h
@@ -66,6 +66,8 @@ class VehicleComponent final : public Component,
 
     float speed_adjuster_;
     float max_velocity_ = 130.f;
+    
+    void AdjustCentreOfMass();
 
     void InitVehicle();
     void InitMaterialFrictionTable();

--- a/game/src/game/components/shooting/Shooter.cpp
+++ b/game/src/game/components/shooting/Shooter.cpp
@@ -62,7 +62,7 @@ void Shooter::ShootDefault(const glm::vec3& origin,
                            const glm::vec3& fwd_direction)
 {
     // check if shot hit anything
-    target_data_ = physics_service_->Raycast(origin, fwd_direction);
+    target_data_ = physics_service_->RaycastDynamic(origin, fwd_direction);
     if (target_data_ && !target_data_.has_value())
     {
         uint32_t entity_id = GetEntity().GetId();
@@ -95,7 +95,7 @@ void Shooter::ShootBuckshot(const glm::vec3& origin,
     {
         std::array<float, 3> spread = {dis(gen) / 4.0f, dis(gen) / 4.0f,
                                        dis(gen) / 4.0f};
-        target_data_ = physics_service_->Raycast(
+        target_data_ = physics_service_->RaycastDynamic(
             origin, glm::normalize(fwd_direction +
                                    glm::vec3(spread[0], 0.0f, spread[2])));
         if (!target_data_ && !target_data_.has_value())
@@ -134,7 +134,7 @@ void Shooter::ShootVampire(const glm::vec3& origin,
                            const glm::vec3& fwd_direction)
 {
     // check if shot hit anything
-    target_data_ = physics_service_->Raycast(origin, fwd_direction);
+    target_data_ = physics_service_->RaycastDynamic(origin, fwd_direction);
     // get the entity that was hit
     if (target_data_.has_value())
     {
@@ -149,7 +149,7 @@ void Shooter::ShootDoubleDamage(const glm::vec3& origin,
                                 const glm::vec3& fwd_direction)
 {
     // check if shot hit anything
-    target_data_ = physics_service_->Raycast(origin, fwd_direction);
+    target_data_ = physics_service_->RaycastDynamic(origin, fwd_direction);
     // get the entity that was hit
     if (target_data_.has_value())
     {
@@ -165,7 +165,7 @@ void Shooter::ShootExploading(const glm::vec3& origin,
                               const glm::vec3& fwd_direction)
 {
     // check if shot hit anything
-    target_data_ = physics_service_->Raycast(origin, fwd_direction);
+    target_data_ = physics_service_->RaycastDynamic(origin, fwd_direction);
     // get the entity that was hit
     if (target_data_.has_value())
     {


### PR DESCRIPTION
added a check to see if a vehicle is currently grounded (very short downwards raycast);
when it isn't: the center of mass shifts *ever so slightly* forward, and vice versa when it is grounded, (hopefully) making it less likely to flop over